### PR TITLE
Fix calls to varargs C functions

### DIFF
--- a/src-ofd/Lukko/OFD.hsc
+++ b/src-ofd/Lukko/OFD.hsc
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE InterruptibleFFI #-}
@@ -116,7 +117,7 @@ hUnlock h = do
 -- implementation
 -------------------------------------------------------------------------------
 
-foreign import ccall interruptible "fcntl"
+foreign import capi interruptible "fcntl.h fcntl"
   c_fcntl :: CInt -> CInt -> Ptr FLock -> IO CInt
 
 data FLock  = FLock { l_type   :: CShort

--- a/src-unix/Lukko/Internal/FD.hsc
+++ b/src-unix/Lukko/Internal/FD.hsc
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE InterruptibleFFI #-}
 {-# LANGUAGE Trustworthy #-}
@@ -27,7 +28,7 @@ import Lukko.Internal.HandleToFD (ghcHandleToFd)
 -- This is a wrapper over 'CInt'
 newtype FD = FD CInt
 
-foreign import ccall interruptible "open"
+foreign import capi interruptible "fcntl.h open"
    c_open :: CString -> CInt -> CMode -> IO CInt
 
 foreign import ccall interruptible "close"


### PR DESCRIPTION
The ccall calling convention doesn't support varargs functions, so
switch to capi instead. See
https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/ffi.html#varargs-not-supported-by-ccall-calling-convention