### PR TITLE
replace ofd-locking flag with no-ofd-locking flag

### DIFF
--- a/lukko.cabal
+++ b/lukko.cabal
@@ -29,7 +29,7 @@ description:
   if os(windows)
   \  cpp-options: -DHAS_WINDOWS_LOCK
   .
-  elif (os(linux) && flag(ofd-locking))
+  elif (os(linux) && !flag(no-ofd-locking))
   \  cpp-options: -DHAS_OFD_LOCKING
   \  cpp-options: -DHAS_FLOCK
   .

--- a/lukko.cabal
+++ b/lukko.cabal
@@ -65,11 +65,11 @@ source-repository head
   type:     git
   location: https://github.com/haskellari/lukko/
 
-flag ofd-locking
-  default:     True
-  manual:      True
+flag no-ofd-locking
+  default:     False
+  manual:      False
   description:
-    Enable open file descriptor locking. Available on Linux (kernel 3.15, released Jun 8, 2014).
+    Disable open file descriptor locking. Available on Linux (kernel 3.15, released Jun 8, 2014).
 
 library
   default-language:   Haskell2010
@@ -88,7 +88,7 @@ library
     exposed-modules: Lukko.Windows
     c-sources:       cbits/windows.c
 
-  elif (os(linux) && flag(ofd-locking))
+  elif (os(linux) && !flag(no-ofd-locking))
     hs-source-dirs:  src-ofd
     hs-source-dirs:  src-flock
     hs-source-dirs:  src-unix
@@ -137,7 +137,7 @@ test-suite test-thread
   if os(windows)
     cpp-options: -DHAS_WINDOWS_LOCK
 
-  elif (os(linux) && flag(ofd-locking))
+  elif (os(linux) && !flag(no-ofd-locking))
     cpp-options: -DHAS_OFD_LOCKING
     cpp-options: -DHAS_FLOCK
 
@@ -158,7 +158,7 @@ test-suite test-process
   if os(windows)
     cpp-options: -DHAS_WINDOWS_LOCK
 
-  elif (os(linux) && flag(ofd-locking))
+  elif (os(linux) && !flag(no-ofd-locking))
     cpp-options: -DHAS_OFD_LOCKING
     cpp-options: -DHAS_FLOCK
 


### PR DESCRIPTION
ofd-locking flag is True by default 
it is difficult to pass False value to cabal(-install)

replacing ofd-locking flag with no-ofd-locking (default: False) allows for problem-free build on linux without OFD support 

see #14 