### PR TITLE
allow base-4.17

### DIFF
--- a/lukko.cabal
+++ b/lukko.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.2
 name:               lukko
 version:            0.1.1.3
-x-revision:         2
+x-revision:         3
 synopsis:           File locking
 category:           System, Concurrency
 description:
@@ -75,7 +75,7 @@ flag ofd-locking
 library
   default-language:   Haskell2010
   hs-source-dirs:     src
-  build-depends:      base >=4.5 && <4.17
+  build-depends:      base >=4.5 && <4.18
   build-tool-depends: hsc2hs:hsc2hs >=0.67 && <0.69
 
   -- Main library module


### PR DESCRIPTION
This depends on phadej/singleton-bool#20

Needed to build cabal-install with ghc-9.4.1