### PR TITLE
Always use 64-bit file offsets

### DIFF
--- a/src-ofd/Lukko/OFD.hsc
+++ b/src-ofd/Lukko/OFD.hsc
@@ -33,6 +33,7 @@ module Lukko.OFD (
     hUnlock,
     ) where
 
+#define _FILE_OFFSET_BITS 64
 #define _GNU_SOURCE
 #include <unistd.h>
 


### PR DESCRIPTION
Previously, OFD locking was broken on 32-bit, because it would somehow end up using the 64-bit `fcntl()` function, but pass it 32-bit `off_t` values in `struct flock`.  To fix this, tell libc to use always use 64-bit file offsets.

This is the same fix that was applied for a [similar issue][1] in GHC.

[1]: https://gitlab.haskell.org/ghc/ghc/-/commit/9853fc5e3556e733b56976b0a2fce9e82130a9ef

Fixes: https://github.com/haskellari/lukko/issues/15